### PR TITLE
chore(CODEOWNERS): add team Giving as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @planningcenter/giving


### PR DESCRIPTION
I'd also like to move the default branch to `main`. Would that be ok?