### PR TITLE
chore(CODEOWNERS): Transfer ownership to the identity team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @planningcenter/giving
+* @planningcenter/identity


### PR DESCRIPTION
The Giving team has split into the Giving & Identity teams. This repo should now be the responsibility of the new Identity team. Let's make it so!